### PR TITLE
Implements more custom events, similar to jquery-ujs/rails-ujs

### DIFF
--- a/lib/hanami/ujs/assets/javascripts/hanami-ujs.js
+++ b/lib/hanami/ujs/assets/javascripts/hanami-ujs.js
@@ -50,7 +50,7 @@ var sameOrigin = function (url) {
 
 window.CSRF = CSRF;
 
-document.addEventListener('ajax:before', function (e) {
+document.addEventListener('ajax:beforeSend', function (e) {
   var token = CSRF.token(), xhr = e.detail;
   if (token)
     xhr.setRequestHeader('X-CSRF-Token', token);
@@ -125,6 +125,9 @@ document.addEventListener('submit', function(event) {
   var form = event.target;
 
   if (matches.call(form, 'form[data-remote]')) {
+    var before = new CustomEvent('ajax:before', {data: data, bubbles: true});
+    form.dispatchEvent(before);
+
     var url = form.action;
     var method = (form.method || form.getAttribute('data-method') || 'POST').toUpperCase();
     var data = new FormData(form);
@@ -133,7 +136,17 @@ document.addEventListener('submit', function(event) {
       data[CSRF.param()] = CSRF.token();
     }
 
-    if (LiteAjax.ajax({ url: url, method: method, data: data, target: form })){
+    var error = function(xhr, target) {
+      var errorEvent = new CustomEvent('ajax:error', {detail: xhr, bubbles: true});
+      target.dispatchEvent(errorEvent);
+    }
+
+    var success = function(xhr, target) {
+      var successEvent = new CustomEvent('ajax:success', {detail: xhr, bubbles: true});
+      target.dispatchEvent(successEvent);
+    }
+
+    if (LiteAjax.ajax({ url: url, method: method, data: data, target: form, success: success, error: error })){
       event.preventDefault();
     } else {
       return true;
@@ -183,16 +196,19 @@ var LiteAjax = (function () {
     if (typeof options.success == 'function')
       xhr.addEventListener('load', function (event) {
         if (xhr.status >= 200 && xhr.status < 300)
-          options.success(xhr);
+          options.success(xhr, target);
+      });
+      xhr.addEventListener('success', function (event) {
+        options.success(xhr, target);
       });
 
     if (typeof options.error == 'function') {
       xhr.addEventListener('load', function (event) {
         if (xhr.status < 200 || xhr.status >= 300)
-          options.error(xhr);
+          options.error(xhr, target);
       });
       xhr.addEventListener('error', function (event) {
-        options.error(xhr);
+        options.error(xhr, target);
       });
     }
 
@@ -205,7 +221,7 @@ var LiteAjax = (function () {
       data = JSON.stringify(data);
     }
 
-    var beforeSend = new CustomEvent('ajax:before', {detail: xhr, bubbles: true});
+    var beforeSend = new CustomEvent('ajax:beforeSend', {detail: xhr, bubbles: true});
     target.dispatchEvent(beforeSend);
     xhr.send(data);
 


### PR DESCRIPTION
Fixes #5 

I've opened this PR because I've found the vanilla-ujs custom events to be insufficient for the project I'm working on, I needed some of the events provided by jquery-ujs/rails-ujs.

Unfortunately this has meant changing the functionality of `ajax:before` which means that these changes couldn't be implemented without breaking the projects currently using this gem. 

So I just wanted to start a conversation really, is there any chance that these types of changes could be implemented in this gem, or would it perhaps make more sense to create an entirely new one?